### PR TITLE
Update ServiceMap.php

### DIFF
--- a/src/ServiceMap.php
+++ b/src/ServiceMap.php
@@ -85,7 +85,7 @@ final class ServiceMap {
         if ($node instanceof String_) {
             $service = $node->value;
         } elseif ($node instanceof ClassConstFetch && $node->class instanceof Name) {
-            $service = $node->class->getFirst();
+            $service = $node->class->toString();
         } else {
             return null;
         }


### PR DESCRIPTION
fix: correct FQCN retrieval in getServiceClassFromNode method

In the getServiceClassFromNode method, replaced the usage of $node->class->getFirst()  with $node->class->toString() to correctly retrieve the full class name (FQCN).  This fix ensures proper handling of fully qualified class names in class constant fetches.